### PR TITLE
Dockerfile: removed statement that broke generation of images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ WORKDIR $HOME
 
 COPY --from=build /go/bin/sdcore-adapter /usr/local/bin/
 
-COPY configs/target_configs target_configs
 COPY tools/scripts scripts
 
 RUN chmod +x ./scripts/run_targets.sh


### PR DESCRIPTION
I didn't think this step was necessary, as these configs will be loaded through Helm chart - maybe I'm on the wrong track?