### PR TITLE
AETHER-2636 Handle delete of device-group or vcs

### DIFF
--- a/pkg/diagapi/api.go
+++ b/pkg/diagapi/api.go
@@ -35,13 +35,14 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/onosproject/onos-lib-go/pkg/logging"
 	"github.com/onosproject/sdcore-adapter/pkg/gnmi"
+	pb "github.com/openconfig/gnmi/proto/gnmi"
 )
 
 var log = logging.GetLogger("diagapi")
 
 // TargetInterface is an interface to a gNMI Target
 type TargetInterface interface {
-	ExecuteCallbacks(reason gnmi.ConfigCallbackType) error
+	ExecuteCallbacks(reason gnmi.ConfigCallbackType, path *pb.Path) error
 	GetJSON() ([]byte, error)
 	PutJSON([]byte) error
 }
@@ -56,7 +57,7 @@ type DiagnosticAPI struct {
 func (m *DiagnosticAPI) reSync(w http.ResponseWriter, r *http.Request) {
 	// TODO: tell the target server to synchronize
 	_ = r
-	err := m.targetServer.ExecuteCallbacks(gnmi.Forced)
+	err := m.targetServer.ExecuteCallbacks(gnmi.Forced, nil)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/pkg/gnmi/defs.go
+++ b/pkg/gnmi/defs.go
@@ -29,14 +29,17 @@ const (
 
 	// Forced is a callback when forced by the user
 	Forced
+
+	// Deleted is for specific paths that are deleted
+	Deleted
 )
 
 func (c ConfigCallbackType) String() string {
-	return [...]string{"Initial", "Apply", "Rollback"}[c]
+	return [...]string{"Initial", "Apply", "Rollback", "Forced", "Delete"}[c]
 }
 
 // ConfigCallback is the signature of the function to apply a validated config to the physical device.
-type ConfigCallback func(ygot.ValidatedGoStruct, ConfigCallbackType) error
+type ConfigCallback func(ygot.ValidatedGoStruct, ConfigCallbackType, *pb.Path) error
 
 var (
 	pbRootPath         = &pb.Path{}

--- a/pkg/gnmi/server.go
+++ b/pkg/gnmi/server.go
@@ -8,6 +8,7 @@ package gnmi
 import (
 	"encoding/json"
 	"github.com/eapache/channels"
+	pb "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/ygot/ygot"
 )
 
@@ -23,7 +24,7 @@ func NewServer(model *Model, config []byte, callback ConfigCallback) (*Server, e
 		callback: callback,
 	}
 	if config != nil && s.callback != nil {
-		if err := s.callback(rootStruct, Initial); err != nil {
+		if err := s.callback(rootStruct, Initial, nil); err != nil {
 			return nil, err
 		}
 	}
@@ -63,9 +64,9 @@ func (s *Server) Close() {
 }
 
 // ExecuteCallbacks executes the callbacks for the synchronizer
-func (s *Server) ExecuteCallbacks(reason ConfigCallbackType) error {
+func (s *Server) ExecuteCallbacks(reason ConfigCallbackType, path *pb.Path) error {
 	if s.callback != nil {
-		if err := s.callback(s.config, reason); err != nil {
+		if err := s.callback(s.config, reason, path); err != nil {
 			return err
 		}
 	}

--- a/pkg/gnmi/util.go
+++ b/pkg/gnmi/util.go
@@ -158,6 +158,23 @@ func gnmiFullPath(prefix, path *pb.Path) *pb.Path {
 	return fullPath
 }
 
+// PathToString converts a gnmi path to a human-readable string
+func PathToString(path *pb.Path) string {
+	parts := []string{}
+	for _, elem := range path.Elem {
+		keys := []string{}
+		for k, v := range elem.Key {
+			keys = append(keys, fmt.Sprintf("%s=%s", k, v))
+		}
+		if len(keys) > 0 {
+			parts = append(parts, fmt.Sprintf("%s[%s]", elem.Name, strings.Join(keys, ",")))
+		} else {
+			parts = append(parts, elem.Name)
+		}
+	}
+	return strings.Join(parts, "/")
+}
+
 // isNIl checks if an interface is nil or its value is nil.
 func isNil(i interface{}) bool {
 	if i == nil {

--- a/pkg/synchronizer/defs.go
+++ b/pkg/synchronizer/defs.go
@@ -9,12 +9,13 @@ import (
 	"time"
 
 	"github.com/onosproject/sdcore-adapter/pkg/gnmi"
+	pb "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/ygot/ygot"
 )
 
 // SynchronizerInterface defines the interface that all synchronizers should have.
 type SynchronizerInterface interface { //nolint
-	Synchronize(config ygot.ValidatedGoStruct, callbackType gnmi.ConfigCallbackType) error
+	Synchronize(config ygot.ValidatedGoStruct, callbackType gnmi.ConfigCallbackType, path *pb.Path) error
 	GetModels() *gnmi.Model
 	SetOutputFileName(fileName string)
 	SetPostEnable(postEnable bool)
@@ -27,4 +28,5 @@ type SynchronizerInterface interface { //nolint
 //go:generate mockgen -destination=../test/mocks/mock_pusher.go -package=mocks github.com/onosproject/sdcore-adapter/pkg/synchronizer PusherInterface
 type PusherInterface interface {
 	PushUpdate(endpoint string, data []byte) error
+	PushDelete(endpoint string) error
 }

--- a/pkg/synchronizer/v3/mem-push.go
+++ b/pkg/synchronizer/v3/mem-push.go
@@ -24,3 +24,9 @@ func (p *MemPusher) PushUpdate(endpoint string, data []byte) error {
 	p.Pushes[endpoint] = string(data)
 	return nil
 }
+
+// PushDelete pushes a delete to the REST endpoint
+func (p *MemPusher) PushDelete(endpoint string) error {
+	_ = endpoint
+	return nil
+}

--- a/pkg/synchronizer/v3/post.go
+++ b/pkg/synchronizer/v3/post.go
@@ -48,3 +48,9 @@ func (p *RESTPusher) PushUpdate(endpoint string, data []byte) error {
 
 	return nil
 }
+
+// PushDelete pushes a delete to the REST endpoint
+func (p *RESTPusher) PushDelete(endpoint string) error {
+	_ = endpoint
+	return fmt.Errorf("Not Implemented")
+}

--- a/pkg/synchronizer/v3/synchronize_test.go
+++ b/pkg/synchronizer/v3/synchronize_test.go
@@ -42,7 +42,7 @@ func TestSynchronizerLoop(t *testing.T) {
 
 	// Normal synchronization
 	mockSynchronizeDeviceReset(0, 0*time.Second)
-	err := sync.Synchronize(config, gnmi.Apply)
+	err := sync.Synchronize(config, gnmi.Apply, nil)
 	assert.Nil(t, err)
 	waitForSyncIdle(t, sync, 5*time.Second)
 	assert.Equal(t, 1, len(mockSynchronizeDeviceCalls))
@@ -51,7 +51,7 @@ func TestSynchronizerLoop(t *testing.T) {
 	// Fail and retry once
 
 	mockSynchronizeDeviceReset(1, 0*time.Second)
-	err = sync.Synchronize(config, gnmi.Apply)
+	err = sync.Synchronize(config, gnmi.Apply, nil)
 	assert.Nil(t, err)
 	waitForSyncIdle(t, sync, 5*time.Second)
 	assert.Equal(t, 1, len(mockSynchronizeDeviceFails))
@@ -60,13 +60,13 @@ func TestSynchronizerLoop(t *testing.T) {
 
 	// several queued changes should only get the last one
 	mockSynchronizeDeviceReset(1, 100*time.Millisecond)
-	err = sync.Synchronize(&mockConfig{}, gnmi.Apply) // this one will fail...
+	err = sync.Synchronize(&mockConfig{}, gnmi.Apply, nil) // this one will fail...
 	assert.Nil(t, err)
-	err = sync.Synchronize(&mockConfig{}, gnmi.Apply) // this one will be ignored...
+	err = sync.Synchronize(&mockConfig{}, gnmi.Apply, nil) // this one will be ignored...
 	assert.Nil(t, err)
-	err = sync.Synchronize(&mockConfig{}, gnmi.Apply) // this one will also be ignored...
+	err = sync.Synchronize(&mockConfig{}, gnmi.Apply, nil) // this one will also be ignored...
 	assert.Nil(t, err)
-	err = sync.Synchronize(config, gnmi.Apply) // this one will succeed!
+	err = sync.Synchronize(config, gnmi.Apply, nil) // this one will succeed!
 	assert.Nil(t, err)
 	waitForSyncIdle(t, sync, 5*time.Second)
 	assert.Equal(t, 1, len(mockSynchronizeDeviceFails))

--- a/pkg/synchronizer/v3/synchronizer.go
+++ b/pkg/synchronizer/v3/synchronizer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/onosproject/onos-lib-go/pkg/logging"
 	"github.com/onosproject/sdcore-adapter/pkg/gnmi"
 	gnmiproto "github.com/openconfig/gnmi/proto/gnmi"
+	pb "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/ygot/ygot"
 	"reflect"
 	"time"
@@ -45,8 +46,14 @@ var ModelData = []*gnmiproto.ModelData{
 }
 
 // Synchronize synchronizes the state to the underlying service.
-func (s *Synchronizer) Synchronize(config ygot.ValidatedGoStruct, callbackType gnmi.ConfigCallbackType) error {
-	err := s.enqueue(config, callbackType)
+func (s *Synchronizer) Synchronize(config ygot.ValidatedGoStruct, callbackType gnmi.ConfigCallbackType, path *pb.Path) error {
+	var err error
+	if callbackType == gnmi.Deleted {
+		// do stuff
+		err = nil
+	} else {
+		err = s.enqueue(config, callbackType)
+	}
 	return err
 }
 

--- a/pkg/synchronizer/v4/delete.go
+++ b/pkg/synchronizer/v4/delete.go
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2020-present Open Networking Foundation <info@opennetworking.org>
+//
+// SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
+
+// Package synchronizerv4 implements a synchronizer for converting sdcore gnmi to json
+package synchronizerv4
+
+/*
+ * Deletes are always handled synchronously. The synchronizer stops and wait for a delete to be
+ * completed before it continues. This is to handle the case where we fail while performing the
+ * delete. It'll get marked as a FAILED transaction in onos-config.
+ *
+ * This is in contrasts to configuration updates, which are generally handled asynchronously.
+ */
+
+import (
+	"fmt"
+	models "github.com/onosproject/config-models/modelplugin/aether-4.0.0/aether_4_0_0"
+	"github.com/onosproject/sdcore-adapter/pkg/gnmi"
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/ygot/ygot"
+)
+
+// GetObjectID return the object id for a path.
+// If the path is a top-level model, then return the id of the object. If
+// the object is not a top-level model then return nil.
+func (s *Synchronizer) GetObjectID(modelName string, path *pb.Path) (*string, error) {
+	// Example path: /vcs/vcs[id=something]
+	if len(path.Elem) > 2 {
+		// It's for some portion of the model, not the root of the model.
+		// We don't care.
+		return nil, nil
+	}
+	if path.Elem[1].Name != modelName {
+		// It's hard to imagine what else this could be. Future-proof by ignoring it.
+		return nil, nil
+	}
+	id, okay := path.Elem[1].Key["id"]
+	if !okay {
+		return nil, fmt.Errorf("Delete of %s does not have an id key", modelName)
+	}
+
+	return &id, nil
+}
+
+// DeleteVcs deletes a Vcs from the core
+func (s *Synchronizer) DeleteVcs(device *models.Device, path *pb.Path) error {
+	id, err := s.GetObjectID("vcs", path)
+	if err != nil {
+		return err
+	}
+	if id == nil {
+		return nil
+	}
+	log.Infof("Delete vcs %s", *id)
+
+	vcs, err := s.GetVcs(device, id)
+	if err != nil {
+		return err
+	}
+
+	// For each connectivity service, delete the VCS from the connectivity
+	// service.
+	csList, err := s.GetConnectivityServiceForSite(device, vcs.Site)
+	if err != nil {
+		return err
+	}
+csLoop:
+	for _, cs := range csList {
+		url := fmt.Sprintf("%s/v1/network-slice/%s", *cs.Core_5GEndpoint, *id)
+		err = s.pusher.PushDelete(url)
+		if err != nil {
+			pushError, ok := err.(*PushError)
+			if ok && pushError.StatusCode == 404 {
+				// This may mean we already deleted it.
+				log.Infof("Tried to delete vcs %s but it does not exist", *id)
+				continue csLoop
+			}
+			return fmt.Errorf("Vcs %s failed to push delete: %s", *id, err)
+		}
+	}
+
+	return nil
+}
+
+// DeleteDeviceGroup deletes a devicegroup from the core
+func (s *Synchronizer) DeleteDeviceGroup(device *models.Device, path *pb.Path) error {
+	id, err := s.GetObjectID("device-group", path)
+	if err != nil {
+		return err
+	}
+	if id == nil {
+		return nil
+	}
+	log.Infof("Delete device-group %s", *id)
+
+	dg, err := s.GetDeviceGroup(device, id)
+	if err != nil {
+		return err
+	}
+
+	csList, err := s.GetConnectivityServiceForSite(device, dg.Site)
+	if err != nil {
+		return err
+	}
+csLoop:
+	for _, cs := range csList {
+		url := fmt.Sprintf("%s/v1/device-group/%s", *cs.Core_5GEndpoint, *id)
+		err = s.pusher.PushDelete(url)
+		if err != nil {
+			pushError, ok := err.(*PushError)
+			if ok && pushError.StatusCode == 404 {
+				// This may mean we already deleted it.
+				log.Infof("Tried to delete vcs %s but it does not exist", *id)
+				continue csLoop
+			}
+			return fmt.Errorf("Device-Group %s failed to push delete: %s", *id, err)
+		}
+	}
+
+	return nil
+}
+
+// HandleDelete synchronously performs a delete
+func (s *Synchronizer) HandleDelete(config ygot.ValidatedGoStruct, path *pb.Path) error {
+	device := config.(*models.Device)
+
+	if path == nil {
+		return nil
+	}
+	if len(path.Elem) == 1 {
+		// Deleting a path of length == 1 could delete an entire class of objects (i.e. all Device-Groups)
+		// at once. The user probably doesn't want to do that.
+		return fmt.Errorf("Refusing to delete path %s because it is too broad", gnmi.PathToString(path))
+	}
+	switch path.Elem[0].Name {
+	case "vcs":
+		return s.DeleteVcs(device, path)
+	case "device-group":
+		return s.DeleteDeviceGroup(device, path)
+	}
+
+	// It for something else.
+	// We don't care.
+
+	return nil
+}

--- a/pkg/synchronizer/v4/post.go
+++ b/pkg/synchronizer/v4/post.go
@@ -13,6 +13,19 @@ import (
 	"time"
 )
 
+// PushError is an error class that is returned for failed POSTs and DELETEs. It
+// makes it easier to detect a nonfatal error, such as a 404.
+type PushError struct {
+	Endpoint   string
+	StatusCode int
+	Status     string
+	Operation  string
+}
+
+func (e *PushError) Error() string {
+	return fmt.Sprintf("Push Error op=%s endpoint=%s code=%d status=%s", e.Operation, e.Endpoint, e.StatusCode, e.Status)
+}
+
 // RESTPusher implements a pusher that pushes to a rest endpoint.
 type RESTPusher struct {
 }
@@ -43,7 +56,36 @@ func (p *RESTPusher) PushUpdate(endpoint string, data []byte) error {
 	log.Infof("Put returned status %s", resp.Status)
 
 	if (resp.StatusCode < 200) || (resp.StatusCode >= 300) {
-		return fmt.Errorf("Put returned error %s", resp.Status)
+		return &PushError{Operation: "POST", Endpoint: endpoint, StatusCode: resp.StatusCode, Status: resp.Status}
+	}
+
+	return nil
+}
+
+// PushDelete pushes a delete to the REST endpoint
+func (p *RESTPusher) PushDelete(endpoint string) error {
+	client := &http.Client{
+		Timeout: time.Second * 10,
+	}
+
+	log.Infof("Push Delete endpoint=%s", endpoint)
+
+	req, err := http.NewRequest("DELETE", endpoint, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	log.Infof("Delete returned status %s", resp.Status)
+
+	if (resp.StatusCode < 200) || (resp.StatusCode >= 300) {
+		return &PushError{Operation: "POST", Endpoint: endpoint, StatusCode: resp.StatusCode, Status: resp.Status}
 	}
 
 	return nil

--- a/pkg/synchronizer/v4/synchronize_test.go
+++ b/pkg/synchronizer/v4/synchronize_test.go
@@ -42,7 +42,7 @@ func TestSynchronizerLoop(t *testing.T) {
 
 	// Normal synchronization
 	mockSynchronizeDeviceReset(0, 0, 0*time.Second)
-	err := sync.Synchronize(config, gnmi.Apply)
+	err := sync.Synchronize(config, gnmi.Apply, nil)
 	assert.Nil(t, err)
 	waitForSyncIdle(t, sync, 5*time.Second)
 	assert.Equal(t, 1, len(mockSynchronizeDeviceCalls))
@@ -51,7 +51,7 @@ func TestSynchronizerLoop(t *testing.T) {
 	// Fail and retry once
 
 	mockSynchronizeDeviceReset(0, 1, 0*time.Second)
-	err = sync.Synchronize(config, gnmi.Apply)
+	err = sync.Synchronize(config, gnmi.Apply, nil)
 	assert.Nil(t, err)
 	waitForSyncIdle(t, sync, 5*time.Second)
 	assert.Equal(t, 1, len(mockSynchronizeDevicePushFails))
@@ -60,13 +60,13 @@ func TestSynchronizerLoop(t *testing.T) {
 
 	// several queued changes should only get the last one
 	mockSynchronizeDeviceReset(0, 1, 100*time.Millisecond)
-	err = sync.Synchronize(&mockConfig{}, gnmi.Apply) // this one will fail...
+	err = sync.Synchronize(&mockConfig{}, gnmi.Apply, nil) // this one will fail...
 	assert.Nil(t, err)
-	err = sync.Synchronize(&mockConfig{}, gnmi.Apply) // this one will be ignored...
+	err = sync.Synchronize(&mockConfig{}, gnmi.Apply, nil) // this one will be ignored...
 	assert.Nil(t, err)
-	err = sync.Synchronize(&mockConfig{}, gnmi.Apply) // this one will also be ignored...
+	err = sync.Synchronize(&mockConfig{}, gnmi.Apply, nil) // this one will also be ignored...
 	assert.Nil(t, err)
-	err = sync.Synchronize(config, gnmi.Apply) // this one will succeed!
+	err = sync.Synchronize(config, gnmi.Apply, nil) // this one will succeed!
 	assert.Nil(t, err)
 	waitForSyncIdle(t, sync, 5*time.Second)
 	assert.Equal(t, 1, len(mockSynchronizeDevicePushFails))

--- a/pkg/synchronizer/v4/synchronizer.go
+++ b/pkg/synchronizer/v4/synchronizer.go
@@ -10,6 +10,7 @@ import (
 	modelplugin "github.com/onosproject/config-models/modelplugin/aether-4.0.0/modelplugin"
 	"github.com/onosproject/onos-lib-go/pkg/logging"
 	"github.com/onosproject/sdcore-adapter/pkg/gnmi"
+	pb "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/ygot/ygot"
 	"reflect"
 	"time"
@@ -20,8 +21,13 @@ import (
 var log = logging.GetLogger("synchronizer")
 
 // Synchronize synchronizes the state to the underlying service.
-func (s *Synchronizer) Synchronize(config ygot.ValidatedGoStruct, callbackType gnmi.ConfigCallbackType) error {
-	err := s.enqueue(config, callbackType)
+func (s *Synchronizer) Synchronize(config ygot.ValidatedGoStruct, callbackType gnmi.ConfigCallbackType, path *pb.Path) error {
+	var err error
+	if callbackType == gnmi.Deleted {
+		return s.HandleDelete(config, path)
+	}
+
+	err = s.enqueue(config, callbackType)
 	return err
 }
 

--- a/pkg/test/mocks/mock_pusher.go
+++ b/pkg/test/mocks/mock_pusher.go
@@ -41,6 +41,14 @@ func (m *MockPusherInterface) PushUpdate(arg0 string, arg1 []byte) error {
 	return ret0
 }
 
+// PushUpdate mocks base method.
+func (m *MockPusherInterface) PushDelete(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PushDelete", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
 // PushUpdate indicates an expected call of PushUpdate.
 func (mr *MockPusherInterfaceMockRecorder) PushUpdate(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()


### PR DESCRIPTION
Sending this your way today; expect to spend tomorrow working on unit tests for it. Tested so far with a Deletes to the config4g pod. The bulk of the changes are in synchronizer/v4/delete.go.

Recommend spending no time on any of the synchronizer/v3 files. I plan to delete the v3 synchronizer as soon as this is in.