### PR TITLE
AETHER-3006 Revert incorrect priority flip

### DIFF
--- a/pkg/synchronizer/synchronize-vcs.go
+++ b/pkg/synchronizer/synchronize-vcs.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (s *Synchronizer) mapPriority(i uint8) uint8 {
-	return 255 - i // UPF expectation is priority is inverse of ROC's priority
+	return i // At one point priority was flipped but this was incorrect
 }
 
 // SynchronizeVcsCore synchronizes the VCSes

--- a/pkg/synchronizer/testdata/sample-vcs-allow-all.json
+++ b/pkg/synchronizer/testdata/sample-vcs-allow-all.json
@@ -30,7 +30,7 @@
     "endpoint": "1.2.3.4/32",
     "action": "permit",
     "protocol": 17,
-    "priority": 248
+    "priority": 7
   },
     {
       "rule-name": "sample-app2-sample-app2-ep",
@@ -39,7 +39,7 @@
       "endpoint": "1.2.3.5/32",
       "action": "deny",
       "protocol": 17,
-      "priority": 247,
+      "priority": 8,
       "app-mbr-downlink": 55667788,
       "app-mbr-uplink": 11223344,
       "bitrate-unit": "bps",
@@ -54,7 +54,7 @@
     {
       "rule-name": "ALLOW-ALL",
       "endpoint": "0.0.0.0/0",
-      "priority": 5,
+      "priority": 250,
       "action": "permit"
     }]
 }

--- a/pkg/synchronizer/testdata/sample-vcs-allow-public.json
+++ b/pkg/synchronizer/testdata/sample-vcs-allow-public.json
@@ -30,7 +30,7 @@
     "endpoint": "1.2.3.4/32",
     "action": "permit",
     "protocol": 17,
-    "priority": 248
+    "priority": 7
   },
     {
       "rule-name": "sample-app2-sample-app2-ep",
@@ -39,7 +39,7 @@
       "endpoint": "1.2.3.5/32",
       "action": "deny",
       "protocol": 17,
-      "priority": 247,
+      "priority": 8,
       "app-mbr-downlink": 55667788,
       "app-mbr-uplink": 11223344,
       "bitrate-unit": "bps",
@@ -54,25 +54,25 @@
     {
       "rule-name": "DENY-CLASS-A",
       "endpoint": "10.0.0.0/8",
-      "priority": 5,
+      "priority": 250,
       "action": "deny"
     },
     {
       "rule-name": "DENY-CLASS-B",
       "endpoint": "172.16.0.0/12",
-      "priority": 4,
+      "priority": 251,
       "action": "deny"
     },
     {
       "rule-name": "DENY-CLASS-C",
       "endpoint": "192.168.0.0/16",
-      "priority": 3,
+      "priority": 252,
       "action": "deny"
     },    
     {
       "rule-name": "ALLOW-ALL",
       "endpoint": "0.0.0.0/0",
-      "priority": 2,
+      "priority": 253,
       "action": "permit"
     }]
 }

--- a/pkg/synchronizer/testdata/sample-vcs.json
+++ b/pkg/synchronizer/testdata/sample-vcs.json
@@ -26,7 +26,7 @@
   "application-filtering-rules": [
     {
       "rule-name": "sample-app-sample-app-ep",
-      "priority": 248,
+      "priority": 7,
       "action": "permit",
       "endpoint": "1.2.3.4/32",
       "dest-port-start": 123,
@@ -35,7 +35,7 @@
     },
     {
       "rule-name": "sample-app2-sample-app2-ep",
-      "priority": 247,
+      "priority": 8,
       "action": "deny",
       "endpoint": "1.2.3.5/32",
       "dest-port-start": 123,
@@ -54,7 +54,7 @@
     },
     {
       "rule-name": "DENY-ALL",
-      "priority": 5,
+      "priority": 250,
       "action": "deny",
       "endpoint": "0.0.0.0/0"
     }

--- a/pkg/synchronizer/testdata/sample-vcs1.json
+++ b/pkg/synchronizer/testdata/sample-vcs1.json
@@ -30,7 +30,7 @@
     "endpoint": "1.2.3.4/32",
     "action": "permit",
     "protocol": 17,
-    "priority": 248
+    "priority": 7 
   },
     {
       "rule-name": "sample-app2-sample-app2-ep",
@@ -39,7 +39,7 @@
       "endpoint": "1.2.3.5/32",
       "action": "deny",
       "protocol": 17,
-      "priority": 247,
+      "priority": 8,
       "app-mbr-downlink": 55667788,
       "app-mbr-uplink": 11223344,
       "bitrate-unit": "bps",
@@ -58,7 +58,7 @@
       "endpoint": "1.2.3.5/32",
       "action": "deny",
       "protocol": 17,
-      "priority": 247,
+      "priority": 8,
       "app-mbr-downlink": 88776655,
       "app-mbr-uplink": 44332211,
       "bitrate-unit": "bps",
@@ -73,7 +73,7 @@
     {
       "rule-name": "DENY-ALL",
       "endpoint": "0.0.0.0/0",
-      "priority": 5,
+      "priority": 250,
       "action": "deny"
     }]
 }

--- a/pkg/synchronizer/testdata/sample-vcs2.json
+++ b/pkg/synchronizer/testdata/sample-vcs2.json
@@ -30,7 +30,7 @@
     "endpoint": "1.2.3.4/32",
     "action": "permit",
     "protocol": 17,
-    "priority": 248
+    "priority": 7 
   },
     {
       "rule-name": "sample-app2-sample-app2-ep",
@@ -39,7 +39,7 @@
       "endpoint": "1.2.3.5/32",
       "action": "deny",
       "protocol": 17,
-      "priority": 247,
+      "priority": 8,
       "app-mbr-downlink": 55667788,
       "app-mbr-uplink": 11223344,
       "bitrate-unit": "bps",
@@ -54,7 +54,7 @@
     {
       "rule-name": "DENY-ALL",
       "endpoint": "0.0.0.0/0",
-      "priority": 5,
+      "priority": 250,
       "action": "deny"
     }]
 }

--- a/pkg/synchronizer/testdata/sample-vcs3.json
+++ b/pkg/synchronizer/testdata/sample-vcs3.json
@@ -27,7 +27,7 @@
     "endpoint": "1.2.3.4/32",
     "action": "permit",
     "protocol": 17,
-    "priority": 248
+    "priority": 7
   },
     {
       "rule-name": "sample-app2-sample-app2-ep",
@@ -36,7 +36,7 @@
       "endpoint": "1.2.3.5/32",
       "action": "deny",
       "protocol": 17,
-      "priority": 247,
+      "priority": 8,
       "app-mbr-downlink": 55667788,
       "app-mbr-uplink": 11223344,
       "bitrate-unit": "bps",
@@ -51,7 +51,7 @@
     {
       "rule-name": "DENY-ALL",
       "endpoint": "0.0.0.0/0",
-      "priority": 5,
+      "priority": 250,
       "action": "deny"
     }]
 }


### PR DESCRIPTION
In Aether 1.6 we flipped priorities in both the ROC and UPF due to a misunderstanding.  This patch reverts the priority inversion in the ROC.  It is the companion patch to https://github.com/omec-project/upf-epc/pull/415
